### PR TITLE
Fix ZFS pool import delays by using cachefiles; Warn if no cachefile; Support multiple ZFS pools

### DIFF
--- a/defaults/initrd.scripts
+++ b/defaults/initrd.scripts
@@ -1097,7 +1097,7 @@ startVolumes() {
 				if [ -r ${ZFS_POOL_CACHEFILE} ]
 				then
 					good_msg "Importing ZFS pool ${ZFS_POOL} using cachefile '${ZFS_POOL_CACHEFILE}'"
-					/sbin/zpool import -N 
+					/sbin/zpool import -N ${ZFS_POOL} -c ${ZFS_POOL_CACHEFILE}
 				else
 					bad_msg "Failed to locate ZFS pool cachefile at '${ZFS_POOL_CACHEFILE}'!"
 					good_msg "Importing ZFS pool ${ZFS_POOL} (this may take awhile)"

--- a/defaults/initrd.scripts
+++ b/defaults/initrd.scripts
@@ -1093,9 +1093,16 @@ startVolumes() {
 					/sbin/zpool import -N ${ZPOOL_FORCE} "${ZFS_POOL}"
 				fi
 			else
-				good_msg "Importing ZFS pool ${ZFS_POOL}"
-
-				/sbin/zpool import -N ${ZPOOL_FORCE} "${ZFS_POOL}"
+				ZFS_POOL_CACHEFILE="/etc/zfs/zfs-pool-${ZFS_POOL}.cache"
+				if [ -r ${ZFS_POOL_CACHEFILE} ]
+				then
+					good_msg "Importing ZFS pool ${ZFS_POOL} using cachefile '${ZFS_POOL_CACHEFILE}'"
+					/sbin/zpool import -N 
+				else
+					bad_msg "Failed to locate ZFS pool cachefile at '${ZFS_POOL_CACHEFILE}'!"
+					good_msg "Importing ZFS pool ${ZFS_POOL} (this may take awhile)"
+					/sbin/zpool import -N ${ZPOOL_FORCE} "${ZFS_POOL}"
+				fi
 
 				if [ "$?" = '0' ]
 				then

--- a/defaults/initrd.scripts
+++ b/defaults/initrd.scripts
@@ -1093,7 +1093,7 @@ startVolumes() {
 					/sbin/zpool import -N ${ZPOOL_FORCE} "${ZFS_POOL}"
 				fi
 			else
-				ZFS_POOL_CACHEFILE="/etc/zfs/zfs-pool-${ZFS_POOL}.cache"
+				ZFS_POOL_CACHEFILE="/etc/zfs/zpool-${ZFS_POOL}.cache"
 				if [ -r ${ZFS_POOL_CACHEFILE} ]
 				then
 					good_msg "Importing ZFS pool ${ZFS_POOL} using cachefile '${ZFS_POOL_CACHEFILE}'"

--- a/defaults/initrd.scripts
+++ b/defaults/initrd.scripts
@@ -1096,19 +1096,19 @@ startVolumes() {
 				ZFS_POOL_CACHEFILE="/etc/zfs/zpool-${ZFS_POOL}.cache"
 				if [ -r ${ZFS_POOL_CACHEFILE} ]
 				then
-					good_msg "Importing ZFS pool ${ZFS_POOL} using cachefile '${ZFS_POOL_CACHEFILE}'"
+					good_msg "Importing ZFS pool '${ZFS_POOL}' using cachefile '${ZFS_POOL_CACHEFILE}'"
 					/sbin/zpool import -N ${ZFS_POOL} -c ${ZFS_POOL_CACHEFILE}
 				else
-					bad_msg "Failed to locate ZFS pool cachefile at '${ZFS_POOL_CACHEFILE}'!"
-					good_msg "Importing ZFS pool ${ZFS_POOL} (this may take awhile)"
+					bad_msg "Failed to locate ZFS pool '{ZFS_POOL}' cachefile at '${ZFS_POOL_CACHEFILE}'!"
+					good_msg "Importing ZFS pool '${ZFS_POOL}' (this may take awhile)"
 					/sbin/zpool import -N ${ZPOOL_FORCE} "${ZFS_POOL}"
 				fi
 
 				if [ "$?" = '0' ]
 				then
-					good_msg "Import of ${ZFS_POOL} succeeded"
+					good_msg "Import of ZFS pool '${ZFS_POOL}' succeeded"
 				else
-					bad_msg "Import of ${ZFS_POOL} failed"
+					bad_msg "Import of ZFS pool '${ZFS_POOL}' failed"
 				fi
 			fi
 		fi

--- a/gen_initramfs.sh
+++ b/gen_initramfs.sh
@@ -507,7 +507,7 @@ append_zfs(){
 			print_warning 1 " No cachefile set on ZFS pool '${pool}'!"
 			print_warning 1 " Startup times will be VERY SLOW as a result."
 			print_warning 1 " To set a cachefile, run a command like this:"
-			print_warning 1 "    zpool set cachefile=/etc/zfs/pool-${pool}.cache ${pool}"
+			print_warning 1 "    zpool set cachefile=/etc/zfs/zpool-${pool}.cache ${pool}"
 			print_warning 1 " ... then re-run genkernel."
 			print_warning 1 "---------------------------------------------------------"
 		else


### PR DESCRIPTION
Compared to the git HEAD of robbat2/genkernel, this pull request:
- fixes broken ZFS silent assumptions about a single cachefile existing with a certain name causing [Gentoo bug 627320](https://bugs.gentoo.org/627320) which many people have run in to
- improves user warnings regarding default import behavior (very slow) if no cachefile is set
- if a cachefile is set, imports it to the initramfs automatically
- adds support for multiple pools