### PR TITLE
Add option to force importing zpool using cache

### DIFF
--- a/defaults/initrd.scripts
+++ b/defaults/initrd.scripts
@@ -1181,7 +1181,7 @@ startVolumes() {
 		then
 			good_msg "Importing ZFS pools"
 
-			/sbin/zpool import -N -a ${ZPOOL_FORCE}
+			/sbin/zpool import -N -a ${ZPOOL_CACHE} ${ZPOOL_FORCE}
 
 			if [ "$?" = '0' ]
 			then
@@ -1199,12 +1199,12 @@ startVolumes() {
 				then
 					good_msg "LUKS detected. Reimporting ${ZFS_POOL}"
 					/sbin/zpool export -f "${ZFS_POOL}"
-					/sbin/zpool import -N ${ZPOOL_FORCE} "${ZFS_POOL}"
+					/sbin/zpool import -N ${ZPOOL_CACHE} ${ZPOOL_FORCE} "${ZFS_POOL}"
 				fi
 			else
 				good_msg "Importing ZFS pool ${ZFS_POOL}"
 
-				/sbin/zpool import -N ${ZPOOL_FORCE} "${ZFS_POOL}"
+				/sbin/zpool import -N ${ZPOOL_CACHE} ${ZPOOL_FORCE} "${ZFS_POOL}"
 
 				if [ "$?" = '0' ]
 				then

--- a/defaults/linuxrc
+++ b/defaults/linuxrc
@@ -111,10 +111,21 @@ do
 		dozfs*)
 			USE_ZFS=1
 
-			if [ "${x#*=}" = 'force' ]
-			then
-				ZPOOL_FORCE=-f
-			fi
+			case "${x#*=}" in
+				*force*)
+					ZPOOL_FORCE=-f
+				;;
+			esac
+
+			case "${x#*=}" in
+				*cache*)
+					if [ -s "/etc/zfs/zpool.cache" ]; then
+						ZPOOL_CACHE="-c /etc/zfs/zpool.cache"
+					else
+						bad_msg "zpool.cache not found or empty, zpool import will be slow"
+					fi
+				;;
+			esac
 		;;
 		dobtrfs*)
 			USE_BTRFS=1

--- a/doc/genkernel.8.txt
+++ b/doc/genkernel.8.txt
@@ -522,9 +522,9 @@ recognized by the kernel itself.
 *domdadm*::
     Scan for RAID arrays on bootup
 
-*dozfs*[=force]::
-    Scan for bootable ZFS pools on bootup. Optionally force import if
-    necessary.
+*dozfs*[=cache,force]::
+    Scan for bootable ZFS pools on bootup. Optionally use cachefile or force import if
+    necessary or perform both actions.
 
 *dobtrfs*::
     Scan for attached Btrfs devices on bootup.


### PR DESCRIPTION
while this https://github.com/robbat2/genkernel/pull/15 approach also works, I prefer mine (obviously)

So I propose this:
Add simple option to pass to kernel via loader.

dozfs=cache will use /etc/zfs/zpool.cache
avoiding 30+ second wait for udev in zpool import

Also it's possible to use both cache and force
at the same time:
dozfs=force,cache (order is not important) will
force import and use cache.

Closes: https://bugs.gentoo.org/627320