### PR TITLE
Add basic zfs encryption support, small fixes

### DIFF
--- a/defaults/linuxrc
+++ b/defaults/linuxrc
@@ -601,7 +601,7 @@ do
 						for i in ${BOOTFS}
 						do
 
-							zfs get type ${i} > /dev/null
+							zfs get type ${i} > /dev/null 2>&1
 							retval=$?
 
 							if [ ${retval} -eq 0 ];	then

--- a/defaults/linuxrc
+++ b/defaults/linuxrc
@@ -639,11 +639,32 @@ do
 			prompt_user "REAL_ROOT" "root block device"
 			got_good_root=0
 
-		# Check for a block device or /dev/nfs
+		# Check for a block device or /dev/nfs or zfs encryption
 		elif [ -b "${REAL_ROOT}" ] || [ "${REAL_ROOT}" = "/dev/nfs" ] || [ "${ROOTFSTYPE}" = "zfs" ]
 		then
-			got_good_root=1
-
+			if [ "${ROOTFSTYPE}" = "zfs" ]; then
+				# at this point we determined dataset and are ready to mount
+				# let's check if this dataset is encrypted and ask for passphrase
+				if [ "$(zpool list -H -o feature@encryption "${REAL_ROOT%%/*}")" = 'active' ]; then
+					ZFS_KEYSTATUS="$(zfs get -H -o value keystatus "${REAL_ROOT}")"
+					ZFS_ENCRYPTIONROOT="$(zfs get -H -o value encryptionroot "${REAL_ROOT}")"
+					if ! [ "${ZFS_ENCRYPTIONROOT}" = '-' ] || [ "${ZFS_KEYSTATUS}" = 'available' ]; then
+						good_msg "Detected ZFS encryption, asking for key"
+						zfs load-key "${ZFS_ENCRYPTIONROOT}"
+						retval=$?
+						# if the key loaded fine, confirm got_good_root to exit second while loop
+						if [ ${retval} -eq 0 ];	then
+							got_good_root=1
+						else
+							bad_msg "${ROOT_DEV} is encrypted and not mountable without key"
+							prompt_user "REAL_ROOT" "root block device"
+							got_good_root=0
+						fi
+					fi
+				fi
+			else
+				got_good_root=1
+			fi
 		else
 			bad_msg "Block device ${REAL_ROOT} is not a valid root device..."
 			REAL_ROOT=""

--- a/defaults/linuxrc
+++ b/defaults/linuxrc
@@ -666,7 +666,7 @@ do
 
 		if [ "${ROOTFSTYPE}" = 'zfs' ]
 		then
-			if [ "zfs get -H -o value mountpoint ${REAL_ROOT}" = 'legacy' ]
+			if [ "$(zfs get -H -o value mountpoint "${REAL_ROOT}")" = 'legacy' ]
 			then
 				MOUNT_STATE=rw
 			else

--- a/defaults/linuxrc
+++ b/defaults/linuxrc
@@ -104,9 +104,9 @@ do
 			DMRAID_OPTS=${x#*=}
 			USE_DMRAID_NORMAL=1
 		;;
-		domultipath) 
-			good_msg "Booting with multipath activated." 
-			USE_MULTIPATH_NORMAL=1 
+		domultipath)
+			good_msg "Booting with multipath activated."
+			USE_MULTIPATH_NORMAL=1
 		;;
 		dozfs*)
 			USE_ZFS=1
@@ -578,9 +578,9 @@ do
 					prompt_user "REAL_ROOT" "root block device"
 					continue
 				fi
-					
+
 				ROOT_DEV="${REAL_ROOT#*=}"
-				if [ "${ROOT_DEV}" != 'ZFS' ] 
+				if [ "${ROOT_DEV}" != 'ZFS' ]
 				then
 					if [ "$(zfs get type -o value -H ${ROOT_DEV})" = 'filesystem' ]
 					then
@@ -609,8 +609,8 @@ do
 								REAL_ROOT=${i}
 								ROOTFSTYPE=zfs
 								break
-							fi	
-						
+							fi
+
 						done;
 
 					else
@@ -623,7 +623,7 @@ do
 					prompt_user "REAL_ROOT" "root block device"
 					got_good_root=0
 				fi
-					
+
 				continue
 				;;
 		esac
@@ -975,7 +975,7 @@ FSTAB
 if [ -f ${NEW_ROOT}/etc/initramfs.mounts ]; then
 	fslist=$(get_mounts_list)
 else
-	fslist="/usr" 
+	fslist="/usr"
 fi
 
 for fs in $fslist; do


### PR DESCRIPTION
This very simple implementation, only supports passphrase.

Inspired by zfs dracut code found in ZoL:
contrib/dracut/90zfs/mount-zfs.sh.in

It does not affect booting ecryption-unaware zfs,
since 'zpool list -H -o feature@encryption ...' will always return 0
even on systems where zfs userland utils do not support encryption at all.

Also some whitespace cleanup (my editor did this)
Fix 'legacy' mountpoint detection which was broken due to missing `$()`.
Fix `no such dataset '-'` messages leaking from stderr.

What I tested so far:
* booting with `root=ZFS` and having bootfs property set, for both encrypted and unencrypted pools.
* booting with `root=ZFS=encrypted/zfs-9999/dataset`
* booting with `root=ZFS=normal/zfs-0.7.9/dataset`
* entering wrong passphrase, it properly drops me to the prompt and asks for root device.
  re-selecting same root device will ask for passphrase again.


Closes: https://bugs.gentoo.org/show_bug.cgi?id=657374