### PR TITLE
Intel RST/Matrix RAID support.

### DIFF
--- a/defaults/initrd.scripts
+++ b/defaults/initrd.scripts
@@ -1074,6 +1074,9 @@ startVolumes() {
 		if [ -x '/sbin/mdadm' ]
 		then
 			/sbin/mdadm --assemble --scan
+			#Intel Matrix RAID (and possibly others) have a container layer above the actual volumes,
+			#So we have to look for volumes that haven't been activated.
+			mdadm -IRs
 		else
 			bad_msg "mdadm not found: skipping mdadm raid assembly!"
 		fi


### PR DESCRIPTION
Intel Matrix RAID uses a nested container structure requiring that the array first be assembled, and then the actual storage volumes be activated.  So we look for those in /proc/mdstat and activate them if we find one (or more).

If there's a better way to do this, let me know.  I was unable to spot one while digging through old forum articles to find what was wrong.  I'm pretty sure it won't mess up other types of software RAID, but cannot claim to have exhaustively tested all of them.