### PR TITLE
Remove unneeded quote escaping inside ``

### DIFF
--- a/defaults/initrd.scripts
+++ b/defaults/initrd.scripts
@@ -894,7 +894,7 @@ cmdline_hwopts() {
 				MY_HWOPTS="${MY_HWOPTS} $x"
 			elif [ "${y}" = "no${x}" ]
 			then
-				MY_HWOPTS="`echo ${MY_HWOPTS} | sed -e \"s/${x}//g\" -`"
+				MY_HWOPTS="$(echo ${MY_HWOPTS} | sed -e "s/${x}//g" -)"
 			fi
 			if [ "$(echo ${y} | cut -b -7)" = "keymap=" ]
 			then


### PR DESCRIPTION
Double quotes don't need to be escaped inside Bash command substitution (either `` ` ` `` or `$()`). However the current code works since `` ` ` `` behaves specially wrt. backslashes (see "Command Substitution" in `man bash`). (That is not the case with `$()`, as sabayon/genkernel-next#49 shows -- genkernel-next upgraded the `` ` ` `` substitution to a `$()` one.)

Still, since the escapes aren't needed, and break `$()`, I suggest they be removed. Also, I upgraded the substitution to a `$()` one, which is IMO easier for humans to parse (in general, not necessarily in this particular case).