### PR TITLE
modules_load: add ecb crypto module

### DIFF
--- a/arch/alpha/modules_load
+++ b/arch/alpha/modules_load
@@ -30,7 +30,7 @@ MODULES_USB="ehci-pci ehci-hcd uhci usb-ohci hid usb-storage uas uhci-hcd ohci-h
 MODULES_FS="ext2 ext3 ext4 btrfs reiserfs jfs nfs xfs zfs f2fs fuse loop squashfs aufs overlay cramfs configfs fscrypto efivarfs msdos qemu_fw_cfg"
 
 # Crypto
-MODULES_CRYPTO="sha256_generic cbc crc32c crc32c_generic crc32 crc32_generic aes_generic xts"
+MODULES_CRYPTO="sha256_generic cbc ecb crc32c crc32c_generic crc32 crc32_generic aes_generic xts"
 
 # Hyper-V
 MODULES_HYPERV="hv_utils hv_vmbus hv_balloon hyperv_keyboard hv_netvsc hid_hyperv hv_utils hyperv_fb hv_storvsc"

--- a/arch/arm/modules_load
+++ b/arch/arm/modules_load
@@ -30,7 +30,7 @@ MODULES_USB="ehci-pci ehci-hcd uhci usb-ohci hid usb-storage uas uhci-hcd ohci-h
 MODULES_FS="ext2 ext3 ext4 btrfs reiserfs jfs nfs xfs zfs f2fs fuse loop squashfs aufs overlay cramfs configfs fscrypto efivarfs msdos qemu_fw_cfg"
 
 # Crypto
-MODULES_CRYPTO="sha256_generic cbc crc32c crc32c_generic crc32 crc32_generic aes_generic xts"
+MODULES_CRYPTO="sha256_generic cbc ecb crc32c crc32c_generic crc32 crc32_generic aes_generic xts"
 
 # Hyper-V
 MODULES_HYPERV="hv_utils hv_vmbus hv_balloon hyperv_keyboard hv_netvsc hid_hyperv hv_utils hyperv_fb hv_storvsc"

--- a/arch/ia64/modules_load
+++ b/arch/ia64/modules_load
@@ -30,7 +30,7 @@ MODULES_USB="ehci-pci ehci-hcd uhci usb-ohci hid usb-storage uas uhci-hcd ohci-h
 MODULES_FS="ext2 ext3 ext4 btrfs reiserfs jfs nfs xfs zfs f2fs fuse loop squashfs aufs overlay cramfs configfs fscrypto efivarfs msdos qemu_fw_cfg"
 
 # Crypto
-MODULES_CRYPTO="sha256_generic cbc crc32c crc32c_generic crc32 crc32_generic aes_generic xts"
+MODULES_CRYPTO="sha256_generic cbc ecb crc32c crc32c_generic crc32 crc32_generic aes_generic xts"
 
 # Hyper-V
 MODULES_HYPERV="hv_utils hv_vmbus hv_balloon hyperv_keyboard hv_netvsc hid_hyperv hv_utils hyperv_fb hv_storvsc"

--- a/arch/mips/modules_load
+++ b/arch/mips/modules_load
@@ -30,7 +30,7 @@ MODULES_USB="ehci-pci ehci-hcd uhci usb-ohci hid usb-storage uas uhci-hcd ohci-h
 MODULES_FS="ext2 ext3 ext4 btrfs reiserfs jfs nfs xfs zfs f2fs fuse loop squashfs aufs overlay cramfs configfs fscrypto efivarfs msdos qemu_fw_cfg"
 
 # Crypto
-MODULES_CRYPTO="sha256_generic cbc crc32c crc32c_generic crc32 crc32_generic crc32-mips aes_generic xts"
+MODULES_CRYPTO="sha256_generic cbc ecb crc32c crc32c_generic crc32 crc32_generic crc32-mips aes_generic xts"
 
 # Hyper-V
 MODULES_HYPERV="hv_utils hv_vmbus hv_balloon hyperv_keyboard hv_netvsc hid_hyperv hv_utils hyperv_fb hv_storvsc"

--- a/arch/parisc/modules_load
+++ b/arch/parisc/modules_load
@@ -30,7 +30,7 @@ MODULES_USB="ehci-pci ehci-hcd uhci usb-ohci hid usb-storage uas uhci-hcd ohci-h
 MODULES_FS="ext2 ext3 ext4 btrfs reiserfs jfs nfs xfs zfs f2fs fuse loop squashfs aufs overlay cramfs configfs fscrypto efivarfs msdos qemu_fw_cfg"
 
 # Crypto
-MODULES_CRYPTO="sha256_generic cbc crc32c crc32c_generic crc32 crc32_generic aes_generic xts"
+MODULES_CRYPTO="sha256_generic cbc ecb crc32c crc32c_generic crc32 crc32_generic aes_generic xts"
 
 # Hyper-V
 MODULES_HYPERV="hv_utils hv_vmbus hv_balloon hyperv_keyboard hv_netvsc hid_hyperv hv_utils hyperv_fb hv_storvsc"

--- a/arch/parisc64/modules_load
+++ b/arch/parisc64/modules_load
@@ -29,7 +29,7 @@ MODULES_USB="ehci-pci ehci-hcd uhci usb-ohci hid usb-storage uas uhci-hcd ohci-h
 MODULES_FS="ext2 ext3 ext4 btrfs reiserfs jfs nfs xfs zfs f2fs fuse loop squashfs aufs overlay cramfs configfs fscrypto efivarfs msdos qemu_fw_cfg"
 
 # Crypto
-MODULES_CRYPTO="sha256_generic cbc crc32c crc32c_generic crc32 crc32_generic aes_generic xts"
+MODULES_CRYPTO="sha256_generic cbc ecb crc32c crc32c_generic crc32 crc32_generic aes_generic xts"
 
 # Hyper-V
 MODULES_HYPERV="hv_utils hv_vmbus hv_balloon hyperv_keyboard hv_netvsc hid_hyperv hv_utils hyperv_fb hv_storvsc"

--- a/arch/ppc/modules_load
+++ b/arch/ppc/modules_load
@@ -30,7 +30,7 @@ MODULES_USB="ehci-pci ehci-hcd uhci usb-ohci hid usb-storage uas uhci-hcd ohci-h
 MODULES_FS="ext2 ext3 ext4 btrfs reiserfs jfs nfs xfs zfs f2fs fuse loop squashfs aufs overlay cramfs configfs fscrypto efivarfs msdos qemu_fw_cfg"
 
 # Crypto
-MODULES_CRYPTO="sha256_generic cbc crc32c crc32c_generic crc32 crc32_generic aes_generic xts"
+MODULES_CRYPTO="sha256_generic cbc ecb crc32c crc32c_generic crc32 crc32_generic aes_generic xts"
 
 # Hyper-V
 MODULES_HYPERV="hv_utils hv_vmbus hv_balloon hyperv_keyboard hv_netvsc hid_hyperv hv_utils hyperv_fb hv_storvsc"

--- a/arch/ppc64/modules_load
+++ b/arch/ppc64/modules_load
@@ -30,7 +30,7 @@ MODULES_USB="ehci-pci ehci-hcd uhci usb-ohci hid usb-storage uas uhci-hcd ohci-h
 MODULES_FS="ext2 ext3 ext4 btrfs reiserfs jfs nfs xfs zfs f2fs fuse loop squashfs aufs overlay cramfs configfs fscrypto efivarfs msdos qemu_fw_cfg"
 
 # Crypto
-MODULES_CRYPTO="sha256_generic cbc crc32c crc32c_generic crc32c-vpmsum crc32 crc32_generic aes_generic xts"
+MODULES_CRYPTO="sha256_generic cbc ecb crc32c crc32c_generic crc32c-vpmsum crc32 crc32_generic aes_generic xts"
 
 # Hyper-V
 MODULES_HYPERV="hv_utils hv_vmbus hv_balloon hyperv_keyboard hv_netvsc hid_hyperv hv_utils hyperv_fb hv_storvsc"

--- a/arch/ppc64le/modules_load
+++ b/arch/ppc64le/modules_load
@@ -30,7 +30,7 @@ MODULES_USB="ehci-pci ehci-hcd uhci usb-ohci hid usb-storage uas uhci-hcd ohci-h
 MODULES_FS="ext2 ext3 ext4 btrfs reiserfs jfs nfs xfs zfs f2fs fuse loop squashfs aufs overlay cramfs configfs fscrypto efivarfs msdos qemu_fw_cfg"
 
 # Crypto
-MODULES_CRYPTO="sha256_generic cbc crc32c crc32c_generic crc32c-vpmsum crc32 crc32_generic aes_generic xts"
+MODULES_CRYPTO="sha256_generic cbc ecb crc32c crc32c_generic crc32c-vpmsum crc32 crc32_generic aes_generic xts"
 
 # Hyper-V
 MODULES_HYPERV="hv_utils hv_vmbus hv_balloon hyperv_keyboard hv_netvsc hid_hyperv hv_utils hyperv_fb hv_storvsc"

--- a/arch/s390/modules_load
+++ b/arch/s390/modules_load
@@ -30,7 +30,7 @@ MODULES_USB="ehci-pci ehci-hcd uhci usb-ohci hid usb-storage uas uhci-hcd ohci-h
 MODULES_FS="ext2 ext3 ext4 btrfs reiserfs jfs nfs xfs zfs f2fs fuse loop squashfs aufs overlay cramfs configfs fscrypto efivarfs msdos qemu_fw_cfg"
 
 # Crypto
-MODULES_CRYPTO="sha256_generic cbc crc32c crc32c_generic crc32 crc32_generic aes_generic xts"
+MODULES_CRYPTO="sha256_generic cbc ecb crc32c crc32c_generic crc32 crc32_generic aes_generic xts"
 
 # Hyper-V
 MODULES_HYPERV="hv_utils hv_vmbus hv_balloon hyperv_keyboard hv_netvsc hid_hyperv hv_utils hyperv_fb hv_storvsc"

--- a/arch/sparc/modules_load
+++ b/arch/sparc/modules_load
@@ -30,7 +30,7 @@ MODULES_USB="ehci-pci ehci-hcd uhci usb-ohci hid usb-storage uas uhci-hcd ohci-h
 MODULES_FS="ext2 ext3 ext4 btrfs reiserfs jfs nfs xfs zfs f2fs fuse loop squashfs aufs overlay cramfs configfs fscrypto efivarfs msdos qemu_fw_cfg"
 
 # Crypto
-MODULES_CRYPTO="sha256_generic cbc crc32c crc32c_generic crc32 crc32_generic aes_generic xts"
+MODULES_CRYPTO="sha256_generic cbc ecb crc32c crc32c_generic crc32 crc32_generic aes_generic xts"
 
 # Hyper-V
 MODULES_HYPERV="hv_utils hv_vmbus hv_balloon hyperv_keyboard hv_netvsc hid_hyperv hv_utils hyperv_fb hv_storvsc"

--- a/arch/sparc64/modules_load
+++ b/arch/sparc64/modules_load
@@ -30,7 +30,7 @@ MODULES_USB="ehci-pci ehci-hcd uhci usb-ohci hid usb-storage uas uhci-hcd ohci-h
 MODULES_FS="ext2 ext3 ext4 btrfs reiserfs jfs nfs xfs zfs f2fs fuse loop squashfs aufs overlay cramfs configfs fscrypto efivarfs msdos qemu_fw_cfg"
 
 # Crypto
-MODULES_CRYPTO="sha256_generic cbc crc32c crc32c_generic crc32c-sparc64 crc32 crc32_generic aes_generic xts"
+MODULES_CRYPTO="sha256_generic cbc ecb crc32c crc32c_generic crc32c-sparc64 crc32 crc32_generic aes_generic xts"
 
 # Hyper-V
 MODULES_HYPERV="hv_utils hv_vmbus hv_balloon hyperv_keyboard hv_netvsc hid_hyperv hv_utils hyperv_fb hv_storvsc"

--- a/arch/um/modules_load
+++ b/arch/um/modules_load
@@ -30,7 +30,7 @@ MODULES_USB="ehci-pci ehci-hcd uhci usb-ohci hid usb-storage uas uhci-hcd ohci-h
 MODULES_FS="ext2 ext3 ext4 btrfs reiserfs jfs nfs xfs zfs f2fs fuse loop squashfs aufs overlay cramfs configfs fscrypto efivarfs msdos qemu_fw_cfg"
 
 # Crypto
-MODULES_CRYPTO="sha256_generic cbc crc32c crc32c_generic crc32 crc32_generic aes_generic xts"
+MODULES_CRYPTO="sha256_generic cbc ecb crc32c crc32c_generic crc32 crc32_generic aes_generic xts"
 
 # Hyper-V
 MODULES_HYPERV="hv_utils hv_vmbus hv_balloon hyperv_keyboard hv_netvsc hid_hyperv hv_utils hyperv_fb hv_storvsc"

--- a/arch/x86/modules_load
+++ b/arch/x86/modules_load
@@ -31,7 +31,7 @@ MODULES_USB="ehci-pci ehci-hcd uhci usb-ohci hid usb-storage uas uhci-hcd ohci-h
 MODULES_FS="ext2 ext3 ext4 btrfs reiserfs jfs nfs xfs zfs f2fs fuse loop squashfs aufs overlay cramfs configfs fscrypto efivarfs msdos qemu_fw_cfg"
 
 # Crypto
-MODULES_CRYPTO="sha256_generic cbc crc32c crc32c_generic crc32c-intel crc32 crc32_generic crc32-pclmul aes_generic aes_586 aesni-intel xts"
+MODULES_CRYPTO="sha256_generic cbc ecb crc32c crc32c_generic crc32c-intel crc32 crc32_generic crc32-pclmul aes_generic aes_586 aesni-intel xts"
 
 # Hyper-V
 MODULES_HYPERV="hv_utils hv_vmbus hv_balloon hyperv_keyboard hv_netvsc hid_hyperv hv_utils hyperv_fb hv_storvsc"

--- a/arch/x86_64/modules_load
+++ b/arch/x86_64/modules_load
@@ -30,7 +30,7 @@ MODULES_USB="ehci-pci ehci-hcd uhci usb-ohci hid usb-storage uas uhci-hcd ohci-h
 MODULES_FS="ext2 ext3 ext4 btrfs reiserfs jfs nfs xfs zfs f2fs fuse loop squashfs aufs overlay cramfs configfs fscrypto efivarfs msdos qemu_fw_cfg"
 
 # Crypto
-MODULES_CRYPTO="sha256_generic cbc crc32c crc32c_generic crc32c-intel crc32 crc32_generic crc32-pclmul aes_generic aes-x86_64 aesni-intel xts"
+MODULES_CRYPTO="sha256_generic cbc ecb crc32c crc32c_generic crc32c-intel crc32 crc32_generic crc32-pclmul aes_generic aes-x86_64 aesni-intel xts"
 
 # Hyper-V
 MODULES_HYPERV="hv_utils hv_vmbus hv_balloon hyperv_keyboard hv_netvsc hid_hyperv hv_utils hyperv_fb hv_storvsc"


### PR DESCRIPTION
Some LUKS volumes depends on "ECB block cipher algorithm" if not included
in the bzImage or at modules in the initramfs we fail to boot the system.